### PR TITLE
Remove helm client-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:3.6
 LABEL maintainer="Igor Zibarev <zibarev.i@gmail.com>"
 
+COPY entrypoint.sh /
+
 ENV KUBECTL_VERSION v1.8.3
 ENV HELM_VERSION 2.7.2
 ENV HELM_FILENAME helm-v${HELM_VERSION}-linux-amd64.tar.gz
@@ -18,4 +20,5 @@ RUN set -ex \
 
 RUN helm init --client-only
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["helm"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ deploy-staging:
         --namespace="${KUBE_NAMESPACE}"
     - kubectl config use-context ${KUBE_NAME}
   script:
-    - helm init --client-only
     - helm install release-name chart/name --namespace ${KUBE_NAMESPACE}
 
 ...

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+helm repo update > /dev/null
+exec $@


### PR DESCRIPTION
Implicit helm --client-init is not evil by itself, but it causes frozen helm chart versions and potentially may lead to surprising bugs, as `helm up` command is almost obligatory although not specified in any docs.

As for me, helm command should fail by default, this is lesser evil in this case.